### PR TITLE
[discover]: add exportCsv/disable document inspect

### DIFF
--- a/src/plugins/discover/public/application/components/data_grid/data_grid.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid.tsx
@@ -18,6 +18,7 @@ import { DOC_HIDE_TIME_COLUMN_SETTING, SAMPLE_SIZE_SETTING } from '../../../../c
 import { UI_SETTINGS } from '../../../../../data/common';
 import { SortOrder } from '../../../saved_searches/types';
 import { useToolbarOptions } from './data_grid_toolbar';
+import { CsvColumnProp, DataGridExportButton } from './data_grid_table_exporter';
 
 export interface DataGridProps {
   columns: string[];
@@ -28,6 +29,7 @@ export interface DataGridProps {
   sort: SortOrder[];
   isToolbarVisible?: boolean;
   isContextView?: boolean;
+  hideInspect?: boolean;
 }
 
 const DataGridUI = ({
@@ -39,6 +41,7 @@ const DataGridUI = ({
   rows,
   isToolbarVisible = true,
   isContextView = false,
+  hideInspect,
 }: DataGridProps) => {
   const services = getServices();
   const rowCount = useMemo(() => (rows ? rows.length : 0), [rows]);
@@ -122,31 +125,38 @@ const DataGridUI = ({
   );
 
   const leadingControlColumns = useMemo(() => {
-    return [
-      {
-        id: 'inspectCollapseColumn',
-        headerCellRender: () => null,
-        rowCellRender: DocViewInspectButton,
-        width: 40,
-      },
-    ];
-  }, []);
+    return !hideInspect
+      ? [
+          {
+            id: 'inspectCollapseColumn',
+            headerCellRender: () => null,
+            rowCellRender: DocViewInspectButton,
+            width: 40,
+          },
+        ]
+      : [];
+  }, [hideInspect]);
 
   return (
-    <EuiDataGrid
-      aria-labelledby="aria-labelledby"
-      columns={displayedTableColumns}
-      columnVisibility={dataGridTableColumnsVisibility}
-      leadingControlColumns={leadingControlColumns}
-      data-test-subj="docTable"
-      pagination={pagination}
-      renderCellValue={renderCellValue}
-      rowCount={rowCount}
-      sorting={sorting}
-      toolbarVisibility={isToolbarVisible ? toolbarOptions : false}
-      rowHeightsOptions={rowHeightsOptions}
-      className="discoverDataGrid"
-    />
+    <>
+      <DataGridExportButton
+        {...{ rows, columns: displayedTableColumns as CsvColumnProp[], legacy: false }}
+      />
+      <EuiDataGrid
+        aria-labelledby="aria-labelledby"
+        columns={displayedTableColumns}
+        columnVisibility={dataGridTableColumnsVisibility}
+        leadingControlColumns={leadingControlColumns}
+        data-test-subj="docTable"
+        pagination={pagination}
+        renderCellValue={renderCellValue}
+        rowCount={rowCount}
+        sorting={sorting}
+        toolbarVisibility={isToolbarVisible ? toolbarOptions : false}
+        rowHeightsOptions={rowHeightsOptions}
+        className="discoverDataGrid"
+      />
+    </>
   );
 };
 

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -12,7 +12,7 @@ import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_
 import { buildColumns } from '../../utils/columns';
 import { DefaultDiscoverTable } from '../default_discover_table/default_discover_table';
 import { DataGrid } from './data_grid';
-import { getNewDiscoverSetting } from '../utils/local_storage';
+import { getDiscoverInspectSetting, getNewDiscoverSetting } from '../utils/local_storage';
 import { SortOrder } from '../../../saved_searches/types';
 
 export interface DataGridTableProps {
@@ -70,6 +70,7 @@ export const DataGridTable = ({
   }
 
   const newDiscoverEnabled = getNewDiscoverSetting(services.storage);
+  const inspectDisabled = getDiscoverInspectSetting(services.storage);
 
   const panelContent = newDiscoverEnabled ? (
     <DataGrid
@@ -81,6 +82,7 @@ export const DataGridTable = ({
       onSetColumns={onSetColumns}
       isToolbarVisible={isToolbarVisible}
       isContextView={isContextView}
+      hideInspect={inspectDisabled}
     />
   ) : (
     <DefaultDiscoverTable
@@ -96,6 +98,7 @@ export const DataGridTable = ({
       onFilter={onFilter}
       onClose={() => setInspectedHit(undefined)}
       showPagination={showPagination}
+      hideInspect={inspectDisabled}
       scrollToTop={scrollToTop}
     />
   );

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_exporter.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_exporter.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { EuiButtonEmpty, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { exportAsCsv } from './utils/convert_to_csv_data';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+
+export interface CsvColumnProp {
+  display?: string;
+  displayName?: string;
+  name?: string;
+  id?: string;
+}
+
+export const DataGridExportButton = (data: {
+  rows: OpenSearchSearchHit[];
+  columns: CsvColumnProp[];
+  legacy: boolean;
+}) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+
+  const closePopover = () => {
+    setPopover(false);
+  };
+  const panels = [
+    {
+      id: 0,
+      items: [
+        {
+          name: 'Export CSV',
+          icon: 'download',
+          onClick: () => exportAsCsv(data),
+        },
+      ],
+    },
+  ];
+  const button = (
+    <EuiButtonEmpty size="s" iconType="download" onClick={() => setPopover((open) => !open)} />
+  );
+  return (
+    <EuiPopover
+      id={'discoverExportCsv'}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenu initialPanelId={0} panels={panels} />
+    </EuiPopover>
+  );
+};

--- a/src/plugins/discover/public/application/components/data_grid/utils/convert_to_csv_data.test.ts
+++ b/src/plugins/discover/public/application/components/data_grid/utils/convert_to_csv_data.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { toCsv } from './convert_to_csv_data';
+
+const legacyColumns = [
+  {
+    name: 'col-1-1',
+    displayName: 'Names',
+  },
+  {
+    name: 'col-1-2',
+    displayName: 'Col2',
+  },
+  {
+    name: 'col-1-3',
+    displayName: 'Col3',
+  },
+];
+
+const columns = [
+  {
+    id: 'col-1-1',
+    display: 'Names',
+  },
+  {
+    id: 'col-1-2',
+    display: 'Col2',
+  },
+  {
+    id: 'col-1-3',
+    display: 'Col3',
+  },
+];
+
+const rows = [
+  {
+    _source: {
+      'col-1-3': 0.6,
+      'col-1-1': 'Alice',
+      'col-1-2': 3,
+    },
+  },
+  {
+    _source: {
+      'col-1-3': 0.2,
+      'col-1-1': 'Anthony',
+      'col-1-2': 1,
+    },
+  },
+  {
+    _source: {
+      'col-1-3': 0.2,
+      'col-1-1': 'Timmy',
+      'col-1-2': 1,
+    },
+  },
+];
+
+describe('toCsv', () => {
+  it('should prepare csv file content for legacy embed', () => {
+    const result = toCsv(rows, legacyColumns, true);
+    expect(result).toEqual(
+      'Names,Col2,Col3\r\nAlice,3,"0.6"\r\nAnthony,1,"0.2"\r\nTimmy,1,"0.2"\r\n'
+    );
+  });
+
+  it('should prepare csv file content for non legacy embed', () => {
+    const result = toCsv(rows, columns, false);
+    expect(result).toEqual(
+      'Names,Col2,Col3\r\nAlice,3,"0.6"\r\nAnthony,1,"0.2"\r\nTimmy,1,"0.2"\r\n'
+    );
+  });
+});

--- a/src/plugins/discover/public/application/components/data_grid/utils/convert_to_csv_data.ts
+++ b/src/plugins/discover/public/application/components/data_grid/utils/convert_to_csv_data.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @ts-ignore
+import { saveAs } from '@elastic/filesaver';
+import { OpenSearchSearchHit } from '../../../doc_views/doc_views_types';
+import { CsvColumnProp } from '../data_grid_table_exporter';
+
+const nonAlphaNumRE = /[^a-zA-Z0-9]/;
+const allDoubleQuoteRE = /"/g;
+
+export const toCsv = function (rows: any, columns: any, legacy: boolean) {
+  function escape(val: any) {
+    val = String(val);
+    if (nonAlphaNumRE.test(val)) {
+      val = '"' + val.replace(allDoubleQuoteRE, '""') + '"';
+    }
+    return val;
+  }
+
+  let csvRows: string[][] = [];
+  for (const row of rows) {
+    const rowArray: string[] = [];
+    for (const col of columns) {
+      let value;
+      if (
+        (legacy && row.fields[col.name] !== undefined) ||
+        (!legacy && row.fields[col.id] !== undefined)
+      ) {
+        value = legacy ? row.fields[col.name] : row.fields[col.id];
+      } else {
+        value = legacy ? row._source[col.name] : row._source[col.id];
+      }
+      rowArray.push(escape(value));
+    }
+    csvRows = [...csvRows, rowArray];
+  }
+
+  // add the columns to the rows
+  csvRows.unshift(
+    columns.map((col: { displayName?: string; display?: string }) =>
+      legacy ? escape(col.displayName) : escape(col.display)
+    )
+  );
+
+  return csvRows.map((row) => row.join() + '\r\n').join('');
+};
+
+export const exportAsCsv = function (data: {
+  rows: OpenSearchSearchHit[];
+  columns: CsvColumnProp[];
+  legacy: boolean;
+}) {
+  const csv = new Blob([toCsv(data.rows, data.columns, data.legacy)], {
+    type: 'text/csv;charset=utf-8',
+  });
+  saveAs(csv, `exported.csv`);
+};

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -195,11 +195,9 @@ const DefaultDiscoverTableUI = ({
              * First cell is skipped because it has a dimention set already, and the last cell is skipped to allow it to
              * grow as much as the table needs.
              */
-            tableElement
-              .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
-              .forEach((th) => {
-                (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
-              });
+            tableElement.querySelectorAll('thead > tr > th:not(:first-child)').forEach((th) => {
+              (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
+            });
 
             tableElement.style.tableLayout = 'fixed';
           }

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -6,7 +6,7 @@
 import './_doc_table.scss';
 
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
-import { EuiButtonEmpty, EuiCallOut, EuiProgress } from '@elastic/eui';
+import { EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiProgress } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { TableHeader } from './table_header';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
@@ -21,6 +21,7 @@ import {
   SORT_DEFAULT_ORDER_SETTING,
 } from '../../../../common';
 import { UI_SETTINGS } from '../../../../../data/common';
+import { CsvColumnProp, DataGridExportButton } from '../data_grid/data_grid_table_exporter';
 
 export interface DefaultDiscoverTableProps {
   columns: string[];
@@ -35,6 +36,7 @@ export interface DefaultDiscoverTableProps {
   onFilter: DocViewFilterFn;
   onClose?: () => void;
   showPagination?: boolean;
+  hideInspect?: boolean;
   scrollToTop?: () => void;
 }
 
@@ -55,6 +57,7 @@ const DefaultDiscoverTableUI = ({
   onFilter,
   onClose,
   showPagination,
+  hideInspect,
   scrollToTop,
 }: DefaultDiscoverTableProps) => {
   const services = getServices();
@@ -177,48 +180,59 @@ const DefaultDiscoverTableUI = ({
   const tableLayoutRequestFrameRef = useRef<number>(0);
 
   useEffect(() => {
-    if (tableElement) {
-      // Load the first batch of rows and adjust the columns to the contents
-      tableElement.style.tableLayout = 'auto';
+    setTimeout(() => {
+      if (tableElement) {
+        // Load the first batch of rows and adjust the columns to the contents
+        tableElement.style.tableLayout = 'auto';
 
-      tableLayoutRequestFrameRef.current = requestAnimationFrame(() => {
-        if (tableElement) {
-          /* Get the widths for each header cell which is the column's width automatically adjusted to the content of
-           * the column. Apply the width as a style and change the layout to fixed. This is to
-           *   1) prevent columns from changing size when more rows are added, and
-           *   2) speed of rendering time of subsequently added rows.
-           *
-           * First cell is skipped because it has a dimention set already, and the last cell is skipped to allow it to
-           * grow as much as the table needs.
-           */
-          tableElement
-            .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
-            .forEach((th) => {
-              (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
-            });
+        tableLayoutRequestFrameRef.current = requestAnimationFrame(() => {
+          if (tableElement) {
+            /* Get the widths for each header cell which is the column's width automatically adjusted to the content of
+             * the column. Apply the width as a style and change the layout to fixed. This is to
+             *   1) prevent columns from changing size when more rows are added, and
+             *   2) speed of rendering time of subsequently added rows.
+             *
+             * First cell is skipped because it has a dimention set already, and the last cell is skipped to allow it to
+             * grow as much as the table needs.
+             */
+            tableElement
+              .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
+              .forEach((th) => {
+                (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
+              });
 
-          tableElement.style.tableLayout = 'fixed';
-        }
-      });
-    }
+            tableElement.style.tableLayout = 'fixed';
+          }
+        });
 
-    return () => cancelAnimationFrame(tableLayoutRequestFrameRef.current);
+        return () => cancelAnimationFrame(tableLayoutRequestFrameRef.current);
+      }
+    }, 300);
   }, [columns, tableElement]);
 
   return (
     indexPattern && (
       <>
-        {showPagination ? (
-          <Pagination
-            pageCount={pageCount}
-            activePage={activePage}
-            goToPage={goToPage}
-            startItem={currentRowCounts.startRow + 1}
-            endItem={currentRowCounts.endRow}
-            totalItems={hits}
-            sampleSize={sampleSize}
-          />
-        ) : null}
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <DataGridExportButton
+              {...{ rows, columns: displayedColumns as CsvColumnProp[], legacy: true }}
+            />
+          </EuiFlexItem>
+          {showPagination ? (
+            <EuiFlexItem grow={true}>
+              <Pagination
+                pageCount={pageCount}
+                activePage={activePage}
+                goToPage={goToPage}
+                startItem={currentRowCounts.startRow + 1}
+                endItem={currentRowCounts.endRow}
+                totalItems={hits}
+                sampleSize={sampleSize}
+              />
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
         <table data-test-subj="docTable" className="osd-table table" ref={tableRef}>
           <thead>
             <TableHeader
@@ -229,6 +243,7 @@ const DefaultDiscoverTableUI = ({
               onMoveColumn={onMoveColumn}
               onRemoveColumn={onRemoveColumn}
               sortOrder={sort}
+              inspect={!hideInspect}
             />
           </thead>
           <tbody>
@@ -245,6 +260,7 @@ const DefaultDiscoverTableUI = ({
                     onFilter={onFilter}
                     onClose={onClose}
                     isShortDots={isShortDots}
+                    inspect={!hideInspect}
                   />
                 );
               }

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -26,6 +26,7 @@ interface Props {
   onRemoveColumn?: (name: string) => void;
   onMoveColumn?: (colName: string, destination: number) => void;
   sortOrder: SortOrder[];
+  inspect: boolean;
 }
 
 export function TableHeader({
@@ -36,10 +37,11 @@ export function TableHeader({
   onMoveColumn,
   onRemoveColumn,
   sortOrder,
+  inspect,
 }: Props) {
   return (
     <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
-      <th style={{ width: '28px' }} />
+      {inspect ? <th style={{ width: '28px' }} /> : <th style={{ width: '0px' }} />}
       {displayedColumns.map((col) => {
         return (
           <TableHeaderColumn

--- a/src/plugins/discover/public/application/components/default_discover_table/table_row.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_row.tsx
@@ -28,6 +28,7 @@ export interface TableRowProps {
   onFilter?: DocViewFilterFn;
   onClose?: () => void;
   isShortDots: boolean;
+  inspect: boolean;
 }
 
 const TableRowUI = ({
@@ -39,6 +40,7 @@ const TableRowUI = ({
   onFilter,
   onClose,
   isShortDots,
+  inspect,
 }: TableRowProps) => {
   const flattened = indexPattern.flattenHit(row);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -48,15 +50,22 @@ const TableRowUI = ({
 
   const tableRow = (
     <tr key={row._id}>
-      <td data-test-subj="docTableExpandToggleColumn" className="osdDocTableCell__toggleDetails">
-        <EuiButtonIcon
-          color="text"
-          onClick={handleExpanding}
-          iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
-          aria-label="Next"
+      {inspect ? (
+        <td data-test-subj="docTableExpandToggleColumn" className="osdDocTableCell__toggleDetails">
+          <EuiButtonIcon
+            color="text"
+            onClick={handleExpanding}
+            iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+            aria-label="Next"
+            data-test-subj="docTableExpandToggleColumn"
+          />
+        </td>
+      ) : (
+        <td
           data-test-subj="docTableExpandToggleColumn"
+          className="osdDocTableCell__toggleDetails"
         />
-      </td>
+      )}
       {columns.map((colName) => {
         const fieldInfo = indexPattern.fields.getByName(colName);
         const fieldMapping = flattened[colName];

--- a/src/plugins/discover/public/application/components/utils/local_storage.ts
+++ b/src/plugins/discover/public/application/components/utils/local_storage.ts
@@ -6,6 +6,7 @@
 import { Storage } from '../../../../../opensearch_dashboards_utils/public';
 
 export const NEW_DISCOVER_KEY = 'discover:newExpereince';
+export const DISCOVER_INSPECT_KEY = 'discover:enableInspect';
 
 export const getNewDiscoverSetting = (storage: Storage): boolean => {
   const storedValue = storage.get(NEW_DISCOVER_KEY);
@@ -14,4 +15,13 @@ export const getNewDiscoverSetting = (storage: Storage): boolean => {
 
 export const setNewDiscoverSetting = (value: boolean, storage: Storage) => {
   storage.set(NEW_DISCOVER_KEY, value);
+};
+
+export const getDiscoverInspectSetting = (storage: Storage): boolean => {
+  const storedValue = storage.get(DISCOVER_INSPECT_KEY);
+  return storedValue !== null ? storedValue : false;
+};
+
+export const setDiscoverInspectSetting = (value: boolean, storage: Storage) => {
+  storage.set(DISCOVER_INSPECT_KEY, value);
 };

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -21,7 +21,12 @@ import { filterColumns } from '../utils/filter_columns';
 import { DEFAULT_COLUMNS_SETTING, MODIFY_COLUMNS_ON_SWITCH } from '../../../../common';
 import { OpenSearchSearchHit } from '../../../application/doc_views/doc_views_types';
 import './discover_canvas.scss';
-import { getNewDiscoverSetting, setNewDiscoverSetting } from '../../components/utils/local_storage';
+import {
+  getDiscoverInspectSetting,
+  getNewDiscoverSetting,
+  setDiscoverInspectSetting,
+  setNewDiscoverSetting,
+} from '../../components/utils/local_storage';
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewProps) {
@@ -99,6 +104,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
 
   const [isOptionsOpen, setOptionsOpen] = useState(false);
   const [useLegacy, setUseLegacy] = useState(!getNewDiscoverSetting(storage));
+  const [disableInspect, setDisableInspect] = useState(getDiscoverInspectSetting(storage));
   const DiscoverOptions = () => (
     <EuiPopover
       button={
@@ -121,7 +127,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
             id: 0,
             title: 'Options',
             content: (
-              <EuiPanel>
+              <EuiPanel paddingSize="s">
                 <EuiSwitch
                   label="Enable legacy Discover"
                   checked={useLegacy}
@@ -130,6 +136,17 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
                     const checked = e.target.checked;
                     setUseLegacy(checked);
                     setNewDiscoverSetting(!checked, storage);
+                    window.location.reload();
+                  }}
+                />
+                <EuiSwitch
+                  label="Disable expand document"
+                  checked={disableInspect}
+                  data-test-subj="discoverOptionsDocumentSwitch"
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setDisableInspect(checked);
+                    setDiscoverInspectSetting(checked, storage);
                     window.location.reload();
                   }}
                 />


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR adds few functionalities to saved search embeds from discover plugin.
New option in discover settings allows user to disable "expand document" feature of saved search and later re-enable it, as well as implementation of Export as CSV.
This PR also includes a fix for incorrect last column placement in case of horizontal scrolling.

Both added features work for both legacy and non-legacy version of embed

### Issues Resolved

Solution for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4995

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

Export CSV:
![image](https://github.com/aver1cal/OpenSearch-DashboardsDiscoverFork/assets/57358089/83dda894-a3e0-4135-8d84-060475c72910)

Toggle document inspect in discover:
![image](https://github.com/aver1cal/OpenSearch-DashboardsDiscoverFork/assets/57358089/b001ae0c-1971-4619-b63b-158499fe29ad)

Last table column width adjustment fix:
![image](https://github.com/aver1cal/OpenSearch-DashboardsDiscoverFork/assets/57358089/88e92306-25d3-4fea-804f-5634499b95e6)
![image](https://github.com/aver1cal/OpenSearch-DashboardsDiscoverFork/assets/57358089/051942d9-17bf-42fe-9bc2-11cffd572a6e)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
1. Populate saved search embed and export CSV
2. Disable/Reenable expand document and test table behavior
3. Add columns to the embed until horizontal scrolling appears and test whether last column has correct behavior

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
feat: Add disable inspect column option in discover settings
feat: Add export as CSV function to saved search embed
fix: Fix last column placement in horizontal scrolling in saved search embed

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
